### PR TITLE
fix(index): Typo in page heading

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 const Index: React.FC = () => (
   <section>
-    <h2>Welcoe!</h2>
+    <h2>Welcome!</h2>
     <p>This is an opinionated template repository for React applications at Canonical, bootstrapped with Vite.</p>
 
     <h3>What's included?</h3>


### PR DESCRIPTION
## Done

- Fixed typo in page heading

## QA

### QA steps

- Go to `/`
- Ensure page heading says "Welcome"

## Fixes

 - Fixes #1 

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/35104482/230326727-0c46c882-3a1a-427a-bfad-4f2a65bbc720.png)

### After
![image](https://user-images.githubusercontent.com/35104482/230326857-8dc4f72e-1ebf-433e-b437-898afd4c38d1.png)

